### PR TITLE
Docs: document PHYSFS_PLATFORM_RAYLIB limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,16 +95,6 @@ Or define `PHYSFS_PLATFORM_RAYLIB` before including the implementation:
 #include "raylib-physfs.h"
 ```
 
-#### Platform integration limitations
-
-When using `PHYSFS_PLATFORM_RAYLIB`, be aware of the following trade-offs:
-
-- **~2 GB file size cap.** `SaveFileData`/`LoadFileData`/`GetFileLength` use `int` for byte counts. Files larger than `INT_MAX` cannot be read, written, or stat'd accurately.
-- **Not thread-safe.** All mutex hooks are no-ops. PhysFS calls into this platform must come from a single thread.
-- **No real user or preference directory.** `__PHYSFS_platformCalcUserDir` and `__PHYSFS_platformCalcPrefDir` fall back to the application directory because raylib doesn't expose `HOME`/`%APPDATA%` equivalents.
-- **No directory deletion.** `__PHYSFS_platformDelete` cannot remove directories; raylib has no API for it.
-- **Whole-file buffering.** Writable handles buffer the entire file in memory until flush/close — not suitable for very large outputs.
-
 ### Defines
 
 Have a look at [Cmake config](CMakeLists.txt) to see how to define different things that change the behavior of physfs, raylib, and raylib-physfs.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ Or define `PHYSFS_PLATFORM_RAYLIB` before including the implementation:
 #include "raylib-physfs.h"
 ```
 
+#### Platform integration limitations
+
+When using `PHYSFS_PLATFORM_RAYLIB`, be aware of the following trade-offs:
+
+- **~2 GB file size cap.** `SaveFileData`/`LoadFileData`/`GetFileLength` use `int` for byte counts. Files larger than `INT_MAX` cannot be read, written, or stat'd accurately.
+- **Not thread-safe.** All mutex hooks are no-ops. PhysFS calls into this platform must come from a single thread.
+- **No real user or preference directory.** `__PHYSFS_platformCalcUserDir` and `__PHYSFS_platformCalcPrefDir` fall back to the application directory because raylib doesn't expose `HOME`/`%APPDATA%` equivalents.
+- **No directory deletion.** `__PHYSFS_platformDelete` cannot remove directories; raylib has no API for it.
+- **Whole-file buffering.** Writable handles buffer the entire file in memory until flush/close — not suitable for very large outputs.
+
 ### Defines
 
 Have a look at [Cmake config](CMakeLists.txt) to see how to define different things that change the behavior of physfs, raylib, and raylib-physfs.

--- a/physfs_platform_raylib.c
+++ b/physfs_platform_raylib.c
@@ -6,6 +6,18 @@
  *   #define PHYSFS_PLATFORM_RAYLIB
  *   #define RAYLIB_PHYSFS_IMPLEMENTATION
  *   #include "raylib-physfs.h"
+ *
+ * Known limitations
+ * -----------------
+ * - ~2 GB file size cap: raylib uses int for byte counts, so files larger
+ *   than INT_MAX cannot be read, written, or stat'd accurately.
+ * - Not thread-safe: all mutex hooks are no-ops; calls must come from a
+ *   single thread.
+ * - No real user/pref directory: falls back to the application directory
+ *   because raylib doesn't expose HOME/%APPDATA% equivalents.
+ * - No directory deletion: raylib has no API to remove directories.
+ * - Whole-file buffering: writable handles buffer the entire file in memory
+ *   until flush/close; not suitable for very large outputs.
  */
 
 #include <limits.h>  /* UINT_MAX */


### PR DESCRIPTION
Documents the known trade-offs of the raylib platform layer in both README.md and physfs_platform_raylib.c. Fixes #45