### PR TITLE
Platform: distinguish missing vs. I/O error in OpenRead

### DIFF
--- a/physfs_platform_raylib.c
+++ b/physfs_platform_raylib.c
@@ -206,7 +206,7 @@ void *__PHYSFS_platformOpenRead(const char *filename)
     unsigned char *raw = LoadFileData(filename, &bytesRead);
     if (raw == NULL) {
         TraceLog(LOG_WARNING, "PHYSFS: platformOpenRead failed: %s", filename);
-        PHYSFS_setErrorCode(PHYSFS_ERR_NOT_FOUND);
+        PHYSFS_setErrorCode(FileExists(filename) ? PHYSFS_ERR_IO : PHYSFS_ERR_NOT_FOUND);
         return NULL;
     }
 


### PR DESCRIPTION
Checks file existence before reporting the error code so callers can tell apart a missing file from a read failure. Fixes #44