### PR TITLE
Platform: stat.createtime set to -1 (unknown)

### DIFF
--- a/physfs_platform_raylib.c
+++ b/physfs_platform_raylib.c
@@ -174,7 +174,7 @@ int __PHYSFS_platformStat(const char *fn, PHYSFS_Stat *stat, const int follow)
         TraceLog(LOG_DEBUG, "PHYSFS: platformStat file: %s", fn);
         stat->filesize   = (PHYSFS_sint64)GetFileLength(fn);
         stat->modtime    = (PHYSFS_sint64)GetFileModTime(fn);
-        stat->createtime = stat->modtime;
+        stat->createtime = -1;
         stat->accesstime = -1;
         stat->filetype   = PHYSFS_FILETYPE_REGULAR;
         stat->readonly   = 0;


### PR DESCRIPTION
Raylib has no creation-time API, so report -1 (unknown) instead of echoing modtime as if it were fact. Fixes #43