### PR TITLE
Platform: error on directory delete

### DIFF
--- a/physfs_platform_raylib.c
+++ b/physfs_platform_raylib.c
@@ -146,6 +146,11 @@ int __PHYSFS_platformMkDir(const char *path)
 
 int __PHYSFS_platformDelete(const char *path)
 {
+    if (DirectoryExists(path)) {
+        TraceLog(LOG_WARNING, "PHYSFS: platformDelete does not support directories: %s", path);
+        PHYSFS_setErrorCode(PHYSFS_ERR_UNSUPPORTED);
+        return 0;
+    }
     if (!FileRemove(path)) {
         TraceLog(LOG_WARNING, "PHYSFS: platformDelete failed: %s", path);
         PHYSFS_setErrorCode(PHYSFS_ERR_OS_ERROR);


### PR DESCRIPTION
Explicitly detects directory paths in __PHYSFS_platformDelete and returns PHYSFS_ERR_UNSUPPORTED so callers get a clear error instead of an ambiguous OS error. Fixes #42