### PR TITLE
Add LoadSoundFromPhysFS()

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ long GetFileModTimeFromPhysFS(const char* fileName);            // Get file modi
 Image LoadImageFromPhysFS(const char* fileName);                // Load an image from PhysFS
 Texture2D LoadTextureFromPhysFS(const char* fileName);          // Load a texture from PhysFS
 Wave LoadWaveFromPhysFS(const char* fileName);                  // Load wave data from PhysFS
+Sound LoadSoundFromPhysFS(const char* fileName);                // Load a sound from PhysFS
 Music LoadMusicStreamFromPhysFS(const char* fileName);          // Load music data from PhysFS
 Font LoadFontFromPhysFS(const char* fileName, int fontSize, int *fontChars, int charsCount);  // Load a font from PhysFS
 Shader LoadShaderFromPhysFS(const char* vsFileName, const char* fsFileName);  // Load shader from PhysFS

--- a/examples/audio/audio_sound_loading.c
+++ b/examples/audio/audio_sound_loading.c
@@ -28,11 +28,8 @@ int main(void)
     // Init PhysFS with the given mount point.
     InitPhysFSEx("resources", "res");
 
-    Wave wav = LoadWaveFromPhysFS("res/sound.wav");
-    Wave ogg = LoadWaveFromPhysFS("res/target.ogg");
-
-    Sound fxWav = LoadSoundFromWave(wav);         // Load WAV audio file
-    Sound fxOgg = LoadSoundFromWave(ogg);        // Load OGG audio file
+    Sound fxWav = LoadSoundFromPhysFS("res/sound.wav");     // Load WAV audio file
+    Sound fxOgg = LoadSoundFromPhysFS("res/target.ogg");    // Load OGG audio file
 
     SetTargetFPS(60);               // Set our game to run at 60 frames-per-second
     //--------------------------------------------------------------------------------------
@@ -61,8 +58,6 @@ int main(void)
 
     // De-Initialization
     //--------------------------------------------------------------------------------------
-    UnloadWave(wav);
-    UnloadWave(ogg);
     UnloadSound(fxWav);     // Unload sound data
     UnloadSound(fxOgg);     // Unload sound data
 

--- a/raylib-physfs.h
+++ b/raylib-physfs.h
@@ -71,6 +71,7 @@ RAYLIB_PHYSFS_DEF Image LoadImageFromPhysFS(const char* fileName);              
 RAYLIB_PHYSFS_DEF Image LoadImageAnimFromPhysFS(const char* fileName, int* frames); // Load an animated image from PhysFS (e.g. GIF)
 RAYLIB_PHYSFS_DEF Texture2D LoadTextureFromPhysFS(const char* fileName);          // Load a texture from PhysFS
 RAYLIB_PHYSFS_DEF Wave LoadWaveFromPhysFS(const char* fileName);                  // Load wave data from PhysFS
+RAYLIB_PHYSFS_DEF Sound LoadSoundFromPhysFS(const char* fileName);                // Load a sound from PhysFS
 RAYLIB_PHYSFS_DEF Music LoadMusicStreamFromPhysFS(const char* fileName);          // Load music data from PhysFS
 RAYLIB_PHYSFS_DEF Font LoadFontFromPhysFS(const char* fileName, int fontSize, int *fontChars, int charsCount);  // Load a font from PhysFS
 RAYLIB_PHYSFS_DEF Shader LoadShaderFromPhysFS(const char* vsFileName, const char* fsFileName);  // Load shader from PhysFS
@@ -448,6 +449,28 @@ Wave LoadWaveFromPhysFS(const char* fileName) {
     Wave wave = LoadWaveFromMemory(extension, fileData, bytesRead);
     UnloadFileData(fileData);
     return wave;
+}
+
+/**
+ * Load a sound from PhysFS.
+ *
+ * @param fileName The file name to load from the PhysFS mount paths.
+ *
+ * @return The Sound object, or an empty Sound object on failure.
+ *
+ * @see UnloadSound()
+ */
+Sound LoadSoundFromPhysFS(const char* fileName) {
+    Wave wave = LoadWaveFromPhysFS(fileName);
+    if (wave.data == NULL) {
+        Sound output = { 0 };
+        return output;
+    }
+
+    // Load the sound from the wave data.
+    Sound sound = LoadSoundFromWave(wave);
+    UnloadWave(wave);
+    return sound;
 }
 
 /**

--- a/test/raylib-physfs-test.c
+++ b/test/raylib-physfs-test.c
@@ -163,6 +163,17 @@ int main(int argc, char *argv[]) {
         AssertEqual(missingWave.data, 0);
     }
 
+    // LoadSoundFromPhysFS()
+    {
+        // Without an audio device, the sound buffer cannot be created, so just
+        // make sure loading an existing file does not crash.
+        Sound sound = LoadSoundFromPhysFS("assets/sound.wav");
+        UnloadSound(sound);
+
+        Sound missingSound = LoadSoundFromPhysFS("MissingFile.wav");
+        AssertEqual(missingSound.stream.buffer, 0);
+    }
+
     // LoadShaderFromPhysFS()
     {
         Shader missingShader = LoadShaderFromPhysFS("MissingFile.txt", "MissingFile.txt");


### PR DESCRIPTION
Adds LoadSoundFromPhysFS() for read-side parity with the other loaders, updates the README API block, simplifies the sound loading example, and adds tests. Fixes #57