### PR TITLE
Platform: create pref directory on disk

### DIFF
--- a/physfs_platform_raylib.c
+++ b/physfs_platform_raylib.c
@@ -95,7 +95,8 @@ char *__PHYSFS_platformCalcUserDir(void)
 }
 
 /**
- * Gets a subdirectory from the application directory.
+ * Gets a subdirectory from the application directory, creating the
+ * org/app directories on disk if they don't already exist.
  *
  * TODO: Add a user pref directory to raylib?
  */
@@ -120,6 +121,16 @@ char *__PHYSFS_platformCalcPrefDir(const char *org, const char *app)
     pos += TextCopy(result + pos, app);
     result[pos++] = '/';
     result[pos]   = '\0';
+
+    /* Create the org/app directories on disk. MakeDirectory() creates any
+     * missing intermediate directories, and succeeds if they already exist. */
+    if (MakeDirectory(result) != 0) {
+        TraceLog(LOG_WARNING, "PHYSFS: platformCalcPrefDir failed to create: %s", result);
+        PHYSFS_setErrorCode(PHYSFS_ERR_OS_ERROR);
+        MemFree(result);
+        return NULL;
+    }
+
     TraceLog(LOG_DEBUG, "PHYSFS: platformCalcPrefDir: %s", result);
     return result;
 }

--- a/test/raylib-physfs-test.c
+++ b/test/raylib-physfs-test.c
@@ -181,12 +181,22 @@ int main(int argc, char *argv[]) {
     Assert(UnmountPhysFS("resources"));
     AssertNot(UnmountPhysFS("MissingDirectory"));
 
-    // SetPhysFSCallbacks()
-    SetPhysFSCallbacks();
-
     // GetPrefDirectory
     const char* perfDir = GetPrefDirectory("RobLoach", "raylib-physfs-test");
     AssertNotEqual(perfDir, 0);
+    Assert(DirectoryExists(perfDir), "GetPrefDirectory() should create the directory on disk");
+
+    // Write into the pref directory
+    {
+        Assert(SetPhysFSWriteDirectory(perfDir));
+        Assert(SaveFileTextToPhysFS("pref-test.txt", "Pref file"));
+        char* prefText = LoadFileText(TextFormat("%spref-test.txt", perfDir));
+        Assert(TextIsEqual(prefText, "Pref file"));
+        UnloadFileText(prefText);
+    }
+
+    // SetPhysFSCallbacks()
+    SetPhysFSCallbacks();
 
     // ClosePhysFS()
     Assert(ClosePhysFS());


### PR DESCRIPTION
Makes __PHYSFS_platformCalcPrefDir() create the org/app directories with MakeDirectory() so GetPrefDirectory() returns a usable path under the raylib platform layer, with the pref-directory test extended to verify creation and a write/read-back. Fixes #56